### PR TITLE
Make api.raml valid yaml

### DIFF
--- a/specifications/raml/api.raml
+++ b/specifications/raml/api.raml
@@ -10,7 +10,7 @@ documentation:
       how to use the API, check out the [Spotify's developer site](https://developer.spotify.com/web-api/).
 schemas:
   - Playlist: !include schemas/playlist.json
-resourceTypes:the
+resourceTypes:
   - base:
       get?: &common
         headers:


### PR DESCRIPTION
remove weird "the" after resourceTypes