### PR TITLE
'maximym' => 'maximum'

### DIFF
--- a/specifications/raml/api.raml
+++ b/specifications/raml/api.raml
@@ -975,21 +975,21 @@ traits:
         description: Minimum key
         required: false
         minimum: 0
-        maximym: 11
+        maximum: 11
       max_key:
         displayName: Max. Key
         type: integer
         description: Maximum key
         required: false
         minimum: 0
-        maximym: 11
+        maximum: 11
       target_key:
         displayName: Target Key
         type: integer
         description: Target key
         required: false
         minimum: 0
-        maximym: 11
+        maximum: 11
       min_liveness:
         displayName: Min. Liveness
         type: number


### PR DESCRIPTION
This typo brakes JS `raml-parser`:
```
YAMLError: unknown property maximym
    at Constructor.__dirname.Validator.Validator.validate_named_parameter (/Users/ivang/dev/api-models/node_modules/raml-parser/lib/validator.js:533:21)
    at Constructor.__dirname.Validator.Validator.valid_common_parameter_properties (/Users/ivang/dev/api-models/node_modules/raml-parser/lib/validator.js:430:21)
    at Constructor.__dirname.Validator.Validator.validate_query_params (/Users/ivang/dev/api-models/node_modules/raml-parser/lib/validator.js:998:28)
    at Constructor.__dirname.Validator.Validator.validate_method (/Users/ivang/dev/api-models/node_modules/raml-parser/lib/validator.js:914:18)
    at Constructor.__dirname.Validator.Validator.validate_resource (/Users/ivang/dev/api-models/node_modules/raml-parser/lib/validator.js:749:34)
    at Constructor.__dirname.Validator.Validator.validate_root_properties (/Users/ivang/dev/api-models/node_modules/raml-parser/lib/validator.js:636:22)
    at Constructor.__dirname.Validator.Validator.validate_document (/Users/ivang/dev/api-models/node_modules/raml-parser/lib/validator.js:75:20)
    at Constructor.__dirname.Composer.Composer.composeRamlTree (/Users/ivang/dev/api-models/node_modules/raml-parser/lib/composer.js:79:14)
    at Constructor.composeRamlTree (/Users/ivang/dev/api-models/node_modules/raml-parser/lib/composer.js:5:61)
```

BTW. I added you API into [my collection](https://github.com/APIs-guru/api-models)